### PR TITLE
Add assembly usage guide and interactive inspector

### DIFF
--- a/guia.md
+++ b/guia.md
@@ -1,0 +1,53 @@
+# Guía de uso de SimuEmu32
+
+Esta guía resume la sintaxis aceptada por el simulador y cómo interactuar con la interfaz para inspeccionar el estado de la CPU.
+
+## Notación básica
+
+- **Registros**: siempre se escriben como `%REGISTRO`, por ejemplo `%EAX`, `%EBX`, `%ESP`.
+- **Inmediatos**: los literales numéricos usan el prefijo `$`, por ejemplo `$10`, `$0xFF`, `$0b1010`.
+- **Direcciones de memoria**: se refieren a la dirección contenida en un registro o símbolo, por ejemplo `(%eax)` o `variable`. Cuando quieras obtener la dirección como inmediato, usa `$variable`.
+- **Separadores**: las instrucciones pueden incluir espacios adicionales, por ejemplo `mov $3, %EBX` es válido.
+
+## Instrucciones soportadas
+
+El simulador actual soporta un conjunto reducido de instrucciones AT&T con operandos en el orden *fuente, destino*:
+
+| Instrucción | Uso | Descripción |
+|-------------|-----|-------------|
+| `mov` | `mov $valor, %REG` | Copia el valor fuente en el destino (solo registro). |
+| `add` | `add $valor, %REG` | Suma el valor fuente al registro destino. |
+| `sub` | `sub %REG, %REG` | Resta el valor fuente del registro destino. |
+| `push` | `push %REG` | Empuja el valor fuente a la pila (decrementa `%ESP`). |
+| `pop` | `pop %REG` | Extrae el valor del tope de la pila al registro destino. |
+| `nop` | `nop` | No realiza ninguna operación, útil para relleno. |
+| `int` | `int $numero` | Simula una interrupción (sin efectos secundarios). |
+
+> **Nota:** por ahora las operaciones entre dos operandos de memoria no están disponibles y cualquier intento mostrará un diagnóstico.
+
+### Ejemplos
+
+```asm
+.data
+  contador: .int 5
+
+.text
+  mov $3, %EBX
+  add %EBX, %EAX
+  push %EAX
+  pop %ECX
+```
+
+## Inspección del estado
+
+- **Registros**: haz clic sobre cualquier tarjeta de registro (por ejemplo `%EAX`) para ver su contenido en binario, decimal con y sin signo, hexadecimal y representación ASCII de los cuatro bytes.
+- **Pila**: cada entrada de la pila es interactiva. Al pulsarla se muestra el valor almacenado junto con la dirección de memoria asociada.
+- **Variables de `.data`**: tras ejecutar el programa, las variables numéricas declaradas con `.byte`, `.word`, `.int` o `.quad` aparecen en el panel de variables. Puedes pulsar cada valor para inspeccionarlo en todos los formatos.
+
+La ventana de inspección puede cerrarse con el botón **Cerrar** o presionando la tecla `Esc`.
+
+## Consejos adicionales
+
+- Usa comentarios con `;` para documentar tu código: `add $1, %EAX ; incrementa el contador`.
+- Ejecuta el programa desde el panel derecho para actualizar los registros, la pila y las variables visibles.
+- Si una instrucción o modo de direccionamiento no está soportado, revisa el panel de diagnósticos para obtener detalles del error.

--- a/src/components/RegistersPanel.tsx
+++ b/src/components/RegistersPanel.tsx
@@ -3,11 +3,12 @@ import { formatRegisterValue } from '../features/simulator/asmSimulator';
 
 interface RegistersPanelProps {
   state: CpuState;
+  onInspect: (label: string, value: number, address?: number) => void;
 }
 
 const registerOrder: RegisterName[] = ['EAX', 'EBX', 'ECX', 'EDX', 'ESI', 'EDI', 'EBP', 'ESP'];
 
-export const RegistersPanel = ({ state }: RegistersPanelProps) => {
+export const RegistersPanel = ({ state, onInspect }: RegistersPanelProps) => {
   return (
     <div className="panel">
       <header>
@@ -15,10 +16,15 @@ export const RegistersPanel = ({ state }: RegistersPanelProps) => {
       </header>
       <div className="registerGrid">
         {registerOrder.map((register) => (
-          <div key={register} className="registerCard">
+          <button
+            key={register}
+            type="button"
+            className="registerCardButton"
+            onClick={() => onInspect(`%${register}`, state.registers[register])}
+          >
             <span className="registerName">{register}</span>
             <span>{formatRegisterValue(state.registers[register])}</span>
-          </div>
+          </button>
         ))}
       </div>
       <div className="flags">

--- a/src/components/StackPanel.tsx
+++ b/src/components/StackPanel.tsx
@@ -3,9 +3,10 @@ import { formatRegisterValue } from '../features/simulator/asmSimulator';
 interface StackPanelProps {
   stack: number[];
   stackPointer: number;
+  onInspect: (label: string, value: number, address?: number) => void;
 }
 
-export const StackPanel = ({ stack, stackPointer }: StackPanelProps) => {
+export const StackPanel = ({ stack, stackPointer, onInspect }: StackPanelProps) => {
   return (
     <div className="panel">
       <header>
@@ -17,10 +18,15 @@ export const StackPanel = ({ stack, stackPointer }: StackPanelProps) => {
         {stack.map((value, index) => {
           const address = stackPointer + index * 4;
           return (
-            <div key={index} className="stackItem">
+            <button
+              key={index}
+              type="button"
+              className="stackItemButton"
+              onClick={() => onInspect(`pila[${index}]`, value, address)}
+            >
               <span>{formatRegisterValue(address)}</span>
               <strong>{formatRegisterValue(value)}</strong>
-            </div>
+            </button>
           );
         })}
       </div>

--- a/src/components/ValueInspector.tsx
+++ b/src/components/ValueInspector.tsx
@@ -1,0 +1,94 @@
+import { useEffect } from 'react';
+import { formatRegisterValue } from '../features/simulator/asmSimulator';
+
+interface ValueInspectorProps {
+  label: string;
+  value: number;
+  address?: number;
+  onClose: () => void;
+}
+
+const formatBinary = (value: number) => (value >>> 0).toString(2).padStart(32, '0');
+
+const chunkBinary = (binary: string) =>
+  binary
+    .match(/.{1,4}/g)
+    ?.join(' ')
+    .replace(/(.{36})/g, '$1\n') ?? binary;
+
+const toSigned = (value: number) => {
+  const unsigned = value >>> 0;
+  return unsigned & 0x80000000 ? unsigned - 0x1_0000_0000 : unsigned;
+};
+
+const toAscii = (value: number) => {
+  const unsigned = value >>> 0;
+  const bytes = [unsigned & 0xff, (unsigned >>> 8) & 0xff, (unsigned >>> 16) & 0xff, (unsigned >>> 24) & 0xff];
+  return bytes
+    .map((byte) => {
+      if (byte === 0) {
+        return '\\0';
+      }
+      if (byte >= 32 && byte <= 126) {
+        return String.fromCharCode(byte);
+      }
+      return '.';
+    })
+    .join('');
+};
+
+export const ValueInspector = ({ label, value, address, onClose }: ValueInspectorProps) => {
+  useEffect(() => {
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  const unsigned = value >>> 0;
+  const signed = toSigned(value);
+  const binary = chunkBinary(formatBinary(value));
+  const hexadecimal = formatRegisterValue(value);
+  const ascii = toAscii(value);
+
+  return (
+    <div className="valueInspectorOverlay" role="dialog" aria-modal="true">
+      <div className="valueInspectorContent">
+        <header className="valueInspectorHeader">
+          <div>
+            <h3>{label}</h3>
+            {typeof address === 'number' && <p>Dirección: {formatRegisterValue(address)}</p>}
+          </div>
+          <button type="button" className="valueInspectorClose" onClick={onClose}>
+            Cerrar
+          </button>
+        </header>
+        <div className="valueInspectorGrid">
+          <div>
+            <span className="valueInspectorLabel">Decimal (con signo)</span>
+            <strong>{signed}</strong>
+          </div>
+          <div>
+            <span className="valueInspectorLabel">Decimal (sin signo)</span>
+            <strong>{unsigned}</strong>
+          </div>
+          <div>
+            <span className="valueInspectorLabel">Hexadecimal</span>
+            <strong>{hexadecimal}</strong>
+          </div>
+          <div>
+            <span className="valueInspectorLabel">ASCII</span>
+            <strong className="valueInspectorAscii">{ascii}</strong>
+          </div>
+        </div>
+        <div className="valueInspectorBinary">
+          <span className="valueInspectorLabel">Binario</span>
+          <code>{binary}</code>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/VariablesPanel.tsx
+++ b/src/components/VariablesPanel.tsx
@@ -1,0 +1,87 @@
+import type { ParsedLine } from '../types';
+import { formatRegisterValue } from '../features/simulator/asmSimulator';
+
+const DATA_DIRECTIVES = new Set(['.byte', '.word', '.int', '.quad']);
+
+type VariableEntry = {
+  name: string;
+  directive: string;
+  values: number[];
+};
+
+interface VariablesPanelProps {
+  analysis?: ParsedLine[];
+  onInspect: (label: string, value: number, address?: number) => void;
+}
+
+const extractVariables = (analysis?: ParsedLine[]): VariableEntry[] => {
+  if (!analysis) {
+    return [];
+  }
+
+  const variables: VariableEntry[] = [];
+
+  analysis.forEach((line) => {
+    if (!line.label || !DATA_DIRECTIVES.has(line.mnemonic)) {
+      return;
+    }
+
+    const values = line.operands
+      .map((operand) => {
+        const value = operand.parsed.value;
+        return typeof value === 'number' ? value : null;
+      })
+      .filter((value): value is number => value !== null);
+
+    if (values.length > 0) {
+      variables.push({
+        name: line.label,
+        directive: line.mnemonic,
+        values,
+      });
+    }
+  });
+
+  return variables;
+};
+
+export const VariablesPanel = ({ analysis, onInspect }: VariablesPanelProps) => {
+  const variables = extractVariables(analysis);
+
+  return (
+    <div className="panel">
+      <header>
+        <h2 className="panelTitle">Variables</h2>
+      </header>
+      {variables.length === 0 ? (
+        <p>No se detectaron variables numéricas en la sección de datos.</p>
+      ) : (
+        <div className="variablesList">
+          {variables.map((variable) => (
+            <div key={variable.name} className="variableCard">
+              <div className="variableHeader">
+                <span className="variableName">{variable.name}</span>
+                <span className="variableDirective">{variable.directive}</span>
+              </div>
+              <div className="variableValues">
+                {variable.values.map((value, index) => {
+                  const label = variable.values.length > 1 ? `${variable.name}[${index}]` : variable.name;
+                  return (
+                    <button
+                      key={`${variable.name}-${index}`}
+                      type="button"
+                      className="variableValueButton"
+                      onClick={() => onInspect(label, value)}
+                    >
+                      {formatRegisterValue(value)}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/features/simulator/asmParser.ts
+++ b/src/features/simulator/asmParser.ts
@@ -1,0 +1,739 @@
+import type {
+  AssemblyAnalysisResult,
+  InstructionCategory,
+  InstructionSize,
+  OperandAddressMode,
+  ParsedLine,
+  ParsedOperand,
+} from '../../types';
+
+type ParseContext = {
+  line: number;
+  label?: string;
+  raw: string;
+};
+
+const SECTION_DIRECTIVES = new Set(['.text', '.data', '.bss', '.rodata']);
+const DATA_DIRECTIVES = new Set(['.byte', '.word', '.int', '.quad', '.ascii', '.asciiz', '.string', '.space']);
+const OTHER_DIRECTIVES = new Set(['.global']);
+
+const PREFIXES = new Set(['rep', 'repe', 'repz', 'repne', 'repnz']);
+
+const REGISTER_SIZES: Record<string, { normalized: string; size: InstructionSize }> = {
+  '%al': { normalized: '%AL', size: 'b' },
+  '%ah': { normalized: '%AH', size: 'b' },
+  '%bl': { normalized: '%BL', size: 'b' },
+  '%bh': { normalized: '%BH', size: 'b' },
+  '%cl': { normalized: '%CL', size: 'b' },
+  '%ch': { normalized: '%CH', size: 'b' },
+  '%dl': { normalized: '%DL', size: 'b' },
+  '%dh': { normalized: '%DH', size: 'b' },
+  '%ax': { normalized: '%AX', size: 'w' },
+  '%bx': { normalized: '%BX', size: 'w' },
+  '%cx': { normalized: '%CX', size: 'w' },
+  '%dx': { normalized: '%DX', size: 'w' },
+  '%si': { normalized: '%SI', size: 'w' },
+  '%di': { normalized: '%DI', size: 'w' },
+  '%bp': { normalized: '%BP', size: 'w' },
+  '%sp': { normalized: '%SP', size: 'w' },
+  '%eax': { normalized: '%EAX', size: 'l' },
+  '%ebx': { normalized: '%EBX', size: 'l' },
+  '%ecx': { normalized: '%ECX', size: 'l' },
+  '%edx': { normalized: '%EDX', size: 'l' },
+  '%esi': { normalized: '%ESI', size: 'l' },
+  '%edi': { normalized: '%EDI', size: 'l' },
+  '%ebp': { normalized: '%EBP', size: 'l' },
+  '%esp': { normalized: '%ESP', size: 'l' },
+};
+
+const isRegister = (value: string) => Object.prototype.hasOwnProperty.call(REGISTER_SIZES, value.toLowerCase());
+
+const LABEL_PATTERN = /^[A-Za-z_][\w]*$/;
+
+const NUMBER_DECIMAL = /^-?\d+$/;
+const NUMBER_HEX = /^-?0x[0-9a-f]+$/i;
+const NUMBER_BINARY = /^-?0b[01]+$/i;
+
+const parseNumber = (text: string): number | null => {
+  if (NUMBER_HEX.test(text)) {
+    return Number.parseInt(text, 16);
+  }
+  if (NUMBER_BINARY.test(text)) {
+    return Number.parseInt(text, 2);
+  }
+  if (NUMBER_DECIMAL.test(text)) {
+    return Number.parseInt(text, 10);
+  }
+  return null;
+};
+
+const toDisplacement = (token: string) => {
+  const trimmed = token.trim();
+  if (!trimmed) {
+    return { symbol: undefined, displacement: undefined, error: undefined };
+  }
+
+  const symbolMatch = trimmed.match(/^([A-Za-z_][\w]*)?(.*)$/);
+  if (!symbolMatch) {
+    return { symbol: undefined, displacement: undefined, error: 'Desplazamiento inválido' };
+  }
+
+  const [, symbol = '', rest] = symbolMatch;
+  const remainder = rest.trim();
+
+  let displacement: number | undefined;
+  if (remainder) {
+    const signMatch = remainder.match(/^([+-])\s*(.+)$/);
+    if (signMatch) {
+      const [, sign, valueText] = signMatch;
+      const parsed = parseNumber(valueText);
+      if (parsed === null) {
+        return { symbol: symbol || undefined, displacement: undefined, error: 'Desplazamiento inválido' };
+      }
+      displacement = sign === '-' ? -parsed : parsed;
+    } else {
+      const parsed = parseNumber(remainder);
+      if (parsed === null) {
+        return { symbol: symbol || undefined, displacement: undefined, error: 'Desplazamiento inválido' };
+      }
+      displacement = parsed;
+    }
+  }
+
+  return { symbol: symbol || undefined, displacement, error: undefined };
+};
+
+const parseScale = (value: string) => {
+  const parsed = parseNumber(value.trim());
+  if (parsed === null) {
+    return { scale: undefined, error: 'Escala inválida' };
+  }
+  if (![1, 2, 4, 8].includes(parsed)) {
+    return { scale: undefined, error: 'La escala debe ser 1, 2, 4 u 8' };
+  }
+  return { scale: parsed, error: undefined };
+};
+
+const determineOperandAddressMode = (operand: ParsedOperand[]): string => {
+  if (operand.length === 0) {
+    return 'sin-operandos';
+  }
+  if (operand.length === 1) {
+    return operand[0].addrMode;
+  }
+  const parts = operand.map((op, index) => `${index === 0 ? 'src' : 'dst'}:${op.addrMode}`);
+  return parts.join(' ');
+};
+
+const createOperand = (
+  kind: ParsedOperand['kind'],
+  text: string,
+  addrMode: OperandAddressMode,
+  parsed: Record<string, unknown>,
+): ParsedOperand => ({
+  kind,
+  text,
+  addrMode,
+  parsed,
+});
+
+const splitOperands = (text: string): string[] => {
+  const result: string[] = [];
+  let buffer = '';
+  let depth = 0;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i];
+    if (char === '(') {
+      depth += 1;
+      buffer += char;
+    } else if (char === ')') {
+      depth = Math.max(0, depth - 1);
+      buffer += char;
+    } else if (char === ',' && depth === 0) {
+      if (buffer.trim()) {
+        result.push(buffer.trim());
+      }
+      buffer = '';
+    } else {
+      buffer += char;
+    }
+  }
+
+  if (buffer.trim()) {
+    result.push(buffer.trim());
+  }
+
+  return result;
+};
+
+const parseImmediate = (raw: string): ParsedOperand | { error: string } => {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith('$')) {
+    return { error: 'Inmediato inválido' };
+  }
+  const valueText = trimmed.slice(1);
+  if (LABEL_PATTERN.test(valueText)) {
+    return createOperand('imm', raw, 'inmediato', { type: 'symbol', symbol: valueText });
+  }
+  const value = parseNumber(valueText);
+  if (value === null) {
+    return { error: 'Inmediato inválido' };
+  }
+  return createOperand('imm', raw, 'inmediato', { value });
+};
+
+const parseRegisterOperand = (raw: string): ParsedOperand | { error: string } => {
+  const trimmed = raw.trim().toLowerCase();
+  if (!isRegister(trimmed)) {
+    return { error: 'Registro inválido' };
+  }
+  const info = REGISTER_SIZES[trimmed];
+  return createOperand('reg', info.normalized, 'registro', { register: info.normalized, size: info.size });
+};
+
+const parseMemoryOperand = (raw: string): { operand?: ParsedOperand; error?: string } => {
+  const cleaned = raw.trim();
+
+  const star = cleaned.startsWith('*');
+  const value = star ? cleaned.slice(1).trim() : cleaned;
+
+  const parenIndex = value.indexOf('(');
+  const hasParens = parenIndex !== -1;
+
+  let displacementToken = '';
+  let inside = '';
+
+  if (hasParens) {
+    const lastParen = value.lastIndexOf(')');
+    if (lastParen === -1 || lastParen < parenIndex) {
+      return { error: 'Paréntesis no balanceados en operando de memoria' };
+    }
+    displacementToken = value.slice(0, parenIndex).trim();
+    inside = value.slice(parenIndex + 1, lastParen).trim();
+  } else {
+    displacementToken = value;
+  }
+
+  const displacementInfo = toDisplacement(displacementToken);
+  if (displacementInfo.error) {
+    return { error: displacementInfo.error };
+  }
+
+  const parsed: Record<string, unknown> = {
+    symbol: displacementInfo.symbol,
+    displacement: displacementInfo.displacement,
+    indirect: star,
+  };
+
+  let addrMode: OperandAddressMode = 'directo';
+
+  if (hasParens) {
+    const parts = inside.split(',').map((part) => part.trim()).filter(Boolean);
+    const [baseRaw, indexRaw, scaleRaw] = parts;
+
+    if (baseRaw) {
+      const baseLower = baseRaw.toLowerCase();
+      if (!isRegister(baseLower)) {
+        return { error: 'Registro base inválido' };
+      }
+      parsed.base = REGISTER_SIZES[baseLower].normalized;
+    }
+
+    if (indexRaw) {
+      const indexLower = indexRaw.toLowerCase();
+      if (!isRegister(indexLower)) {
+        return { error: 'Registro índice inválido' };
+      }
+      parsed.index = REGISTER_SIZES[indexLower].normalized;
+    }
+
+    if (scaleRaw) {
+      const { scale, error } = parseScale(scaleRaw);
+      if (error) {
+        return { error };
+      }
+      parsed.scale = scale;
+    }
+
+    const hasBase = Boolean(parsed.base);
+    const hasIndex = Boolean(parsed.index);
+    const hasDisplacement = parsed.displacement !== undefined || parsed.symbol !== undefined;
+    const hasScale = parsed.scale !== undefined;
+
+    if (hasBase && hasIndex && (hasDisplacement || hasScale)) {
+      addrMode = 'base+indice+desp';
+    } else if (hasBase && hasIndex) {
+      addrMode = 'base+indice';
+    } else if (!hasBase && hasIndex && (hasDisplacement || hasScale)) {
+      addrMode = hasScale ? 'indice-escalado' : 'base+indice';
+    } else if (hasBase && hasDisplacement) {
+      addrMode = 'base+desp';
+    } else if (hasBase) {
+      addrMode = 'indirecto';
+    } else if (hasIndex) {
+      addrMode = hasScale ? 'indice-escalado' : 'indirecto';
+    } else if (hasDisplacement) {
+      addrMode = 'directo';
+    } else {
+      addrMode = 'desconocido';
+    }
+  } else if (displacementInfo.symbol || displacementInfo.displacement !== undefined) {
+    addrMode = 'directo';
+  }
+
+  return {
+    operand: createOperand('mem', cleaned, addrMode, parsed),
+  };
+};
+
+const normalizeMnemonic = (mnemonic: string) => mnemonic.trim().toLowerCase();
+
+const extractSizeSuffix = (mnemonic: string): { base: string; size: InstructionSize } => {
+  if (mnemonic.length > 1) {
+    const suffix = mnemonic[mnemonic.length - 1];
+    if (suffix === 'b' || suffix === 'w' || suffix === 'l') {
+      return { base: mnemonic.slice(0, -1), size: suffix };
+    }
+  }
+  return { base: mnemonic, size: 'inferido' };
+};
+
+const SIGNED_CONDITIONS = new Set(['g', 'ge', 'l', 'le', 's', 'ns']);
+const UNSIGNED_CONDITIONS = new Set(['a', 'ae', 'b', 'be', 'na', 'nae', 'nb', 'nbe', 'c', 'nc']);
+
+const CONDITION_FLAG_MAP: Record<string, string[]> = {
+  e: ['ZF'],
+  z: ['ZF'],
+  ne: ['ZF'],
+  nz: ['ZF'],
+  s: ['SF'],
+  ns: ['SF'],
+  g: ['ZF', 'SF', 'OF'],
+  ge: ['SF', 'OF'],
+  l: ['SF', 'OF'],
+  le: ['ZF', 'SF', 'OF'],
+  a: ['CF', 'ZF'],
+  ae: ['CF'],
+  b: ['CF'],
+  be: ['CF', 'ZF'],
+  na: ['CF', 'ZF'],
+  nae: ['CF'],
+  nb: ['CF'],
+  nbe: ['CF', 'ZF'],
+  c: ['CF'],
+  nc: ['CF'],
+  o: ['OF'],
+  no: ['OF'],
+  p: ['PF'],
+  pe: ['PF'],
+  po: ['PF'],
+  np: ['PF'],
+};
+
+const FLAG_WRITES: Record<string, string[]> = {
+  add: ['CF', 'OF', 'SF', 'ZF'],
+  adc: ['CF', 'OF', 'SF', 'ZF'],
+  sub: ['CF', 'OF', 'SF', 'ZF'],
+  sbb: ['CF', 'OF', 'SF', 'ZF'],
+  inc: ['OF', 'SF', 'ZF'],
+  dec: ['OF', 'SF', 'ZF'],
+  neg: ['CF', 'OF', 'SF', 'ZF'],
+  mul: ['CF', 'OF'],
+  imul: ['CF', 'OF'],
+  imul3: ['CF', 'OF'],
+  div: [],
+  idiv: [],
+  and: ['CF', 'OF', 'SF', 'ZF'],
+  or: ['CF', 'OF', 'SF', 'ZF'],
+  xor: ['CF', 'OF', 'SF', 'ZF'],
+  not: [],
+  shl: ['CF', 'OF', 'SF', 'ZF'],
+  sal: ['CF', 'OF', 'SF', 'ZF'],
+  shr: ['CF', 'OF', 'SF', 'ZF'],
+  sar: ['CF', 'OF', 'SF', 'ZF'],
+  rol: ['CF', 'OF'],
+  ror: ['CF', 'OF'],
+  rcl: ['CF', 'OF'],
+  rcr: ['CF', 'OF'],
+  test: ['CF', 'OF', 'SF', 'ZF'],
+  cmp: ['CF', 'OF', 'SF', 'ZF'],
+};
+
+const categorizeMnemonic = (mnemonic: string): InstructionCategory => {
+  const base = mnemonic.startsWith('mov') ? 'mov' : mnemonic;
+
+  if (['mov', 'movzb', 'movsb', 'movsw', 'movsl', 'cbt', 'cwt', 'cwd', 'clt', 'xchg', 'lea'].some((prefix) => base.startsWith(prefix))) {
+    return 'data';
+  }
+  if (['push', 'pop'].includes(base)) {
+    return 'stack';
+  }
+  if (['add', 'sub', 'adc', 'sbb', 'inc', 'dec', 'neg', 'mul', 'imul', 'div', 'idiv'].includes(base)) {
+    return 'arith';
+  }
+  if (['and', 'or', 'xor', 'not'].includes(base)) {
+    return 'logic';
+  }
+  if (['shl', 'sal', 'shr', 'sar', 'rol', 'ror', 'rcl', 'rcr'].includes(base)) {
+    return 'shift';
+  }
+  if (['cmp', 'test'].includes(base)) {
+    return 'verify';
+  }
+  if (base.startsWith('set')) {
+    return 'setcc';
+  }
+  if (base.startsWith('cmov')) {
+    return 'cmov';
+  }
+  if (base.startsWith('j') || base === 'loop' || base === 'call' || base === 'ret') {
+    return 'branch';
+  }
+  if (['lods', 'stos', 'movs', 'scas', 'cmps'].some((prefix) => base.startsWith(prefix))) {
+    return 'string';
+  }
+  if (PREFIXES.has(base)) {
+    return 'string';
+  }
+  if (['cld', 'std'].includes(base)) {
+    return 'string';
+  }
+  return 'misc';
+};
+
+const normalizeMovVariant = (mnemonic: string) => {
+  if (mnemonic.startsWith('movz')) {
+    return 'movz';
+  }
+  if (mnemonic.startsWith('movs')) {
+    return 'movs';
+  }
+  return 'mov';
+};
+
+const getFlagWrites = (mnemonic: string, operands: ParsedOperand[]): string[] => {
+  const base = mnemonic.startsWith('mov') ? normalizeMovVariant(mnemonic) : mnemonic;
+  if (FLAG_WRITES[base]) {
+    return FLAG_WRITES[base];
+  }
+  if (FLAG_WRITES[mnemonic]) {
+    return FLAG_WRITES[mnemonic];
+  }
+  if (mnemonic === 'cbtw' || mnemonic === 'cwtl' || mnemonic === 'cwtd' || mnemonic === 'cltd') {
+    return [];
+  }
+  if (mnemonic.startsWith('set')) {
+    return [];
+  }
+  if (mnemonic.startsWith('cmov')) {
+    return [];
+  }
+  if (mnemonic === 'push' || mnemonic === 'pop' || mnemonic === 'lea') {
+    return [];
+  }
+  if (mnemonic.startsWith('j') || mnemonic === 'call' || mnemonic === 'ret' || mnemonic === 'loop') {
+    return [];
+  }
+  if (PREFIXES.has(mnemonic) || ['lodsb', 'lodsw', 'lodsl', 'stosb', 'stosw', 'stosl', 'movsb', 'movsw', 'movsl', 'scasb', 'scasw', 'scasl', 'cmpsb', 'cmpsw', 'cmpsl'].includes(mnemonic)) {
+    return [];
+  }
+  if (mnemonic === 'cld' || mnemonic === 'std') {
+    return [];
+  }
+  return [];
+};
+
+const getFlagReads = (mnemonic: string, operands: ParsedOperand[]): string[] => {
+  if (mnemonic.startsWith('j')) {
+    const condition = mnemonic.slice(1);
+    return CONDITION_FLAG_MAP[condition] ?? [];
+  }
+  if (mnemonic.startsWith('set')) {
+    const condition = mnemonic.slice(3);
+    return CONDITION_FLAG_MAP[condition] ?? [];
+  }
+  if (mnemonic.startsWith('cmov')) {
+    const condition = mnemonic.slice(4);
+    return CONDITION_FLAG_MAP[condition] ?? [];
+  }
+  if (mnemonic === 'loop') {
+    return [];
+  }
+  if (mnemonic === 'ret') {
+    return [];
+  }
+  if (mnemonic === 'call') {
+    return [];
+  }
+  if (mnemonic === 'imul' && operands.length === 3) {
+    return ['CF', 'OF'];
+  }
+  return [];
+};
+
+const validateInstructionOperands = (mnemonic: string, operands: ParsedOperand[]): string[] => {
+  const errors: string[] = [];
+
+  const baseMnemonic = mnemonic.startsWith('mov') ? 'mov' : mnemonic;
+
+  if (baseMnemonic === 'mov' && operands.length === 2) {
+    if (operands[0].kind === 'mem' && operands[1].kind === 'mem') {
+      errors.push('mov no permite memoria a memoria');
+    }
+  }
+
+  if (['push', 'pop'].includes(baseMnemonic) && operands.length !== 1) {
+    errors.push(`${baseMnemonic} requiere un operando`);
+  }
+
+  if (['add', 'sub', 'and', 'or', 'xor', 'cmp', 'test', 'mov', 'xchg', 'lea'].includes(baseMnemonic) && operands.length !== 2) {
+    errors.push(`${baseMnemonic} requiere dos operandos`);
+  }
+
+  if (['mul', 'div', 'idiv', 'neg', 'not'].includes(baseMnemonic) && operands.length !== 1) {
+    errors.push(`${baseMnemonic} requiere un operando`);
+  }
+
+  if (baseMnemonic.startsWith('j') && operands.length !== 1) {
+    errors.push(`${mnemonic} requiere un destino`);
+  }
+
+  if (baseMnemonic.startsWith('set') && operands.length !== 1) {
+    errors.push(`${mnemonic} requiere un destino`);
+  }
+
+  if (baseMnemonic.startsWith('cmov') && operands.length !== 2) {
+    errors.push(`${mnemonic} requiere dos operandos`);
+  }
+
+  if (baseMnemonic === 'loop' && operands.length !== 1) {
+    errors.push('loop requiere una etiqueta destino');
+  }
+
+  if (baseMnemonic === 'call' && operands.length !== 1) {
+    errors.push('call requiere un destino');
+  }
+
+  if (baseMnemonic === 'ret' && operands.length > 1) {
+    errors.push('ret admite a lo sumo un operando inmediato');
+  }
+
+  return errors;
+};
+
+const normalizeLabelUsage = (mnemonic: string, operands: ParsedOperand[]): ParsedOperand[] => {
+  const category = categorizeMnemonic(mnemonic);
+  if (category !== 'branch') {
+    return operands;
+  }
+
+  return operands.map((operand) => {
+    if (operand.kind === 'mem') {
+      const { base, index, scale } = operand.parsed;
+      if (!base && !index && scale === undefined) {
+        const next: ParsedOperand = {
+          ...operand,
+          kind: 'label',
+          addrMode: 'relativo',
+        };
+        return next;
+      }
+    }
+    return operand;
+  });
+};
+
+const parseOperands = (operandsText: string): (ParsedOperand | { error: string })[] => {
+  if (!operandsText.trim()) {
+    return [];
+  }
+  const rawOperands = splitOperands(operandsText);
+  return rawOperands.map((operandText) => {
+    if (operandText.startsWith('$')) {
+      return parseImmediate(operandText);
+    }
+    if (operandText.startsWith('%')) {
+      return parseRegisterOperand(operandText);
+    }
+    if (operandText.startsWith('*')) {
+      const { operand, error } = parseMemoryOperand(operandText);
+      return operand ?? { error: error ?? 'Operando indirecto inválido' };
+    }
+    if (operandText.includes('(') || operandText.includes(')')) {
+      const { operand, error } = parseMemoryOperand(operandText);
+      return operand ?? { error: error ?? 'Operando de memoria inválido' };
+    }
+    if (LABEL_PATTERN.test(operandText) || operandText.includes('+') || operandText.includes('-')) {
+      const { operand, error } = parseMemoryOperand(operandText);
+      return operand ?? { error: error ?? 'Operando simbólico inválido' };
+    }
+    const { operand, error } = parseMemoryOperand(operandText);
+    return operand ?? { error: error ?? 'Operando inválido' };
+  });
+};
+
+const buildInstructionLine = (context: ParseContext, mnemonic: string, operands: ParsedOperand[], prefixes: string[] = []): ParsedLine => {
+  const { base, size } = extractSizeSuffix(mnemonic);
+  const normalizedMnemonic = base;
+  const normalizedOperands = normalizeLabelUsage(normalizedMnemonic, operands);
+  const addrMode = determineOperandAddressMode(normalizedOperands);
+  const category = categorizeMnemonic(normalizedMnemonic);
+  const writes = getFlagWrites(normalizedMnemonic, normalizedOperands);
+  const reads = getFlagReads(normalizedMnemonic, normalizedOperands);
+
+  return {
+    line: context.line,
+    label: context.label,
+    mnemonic: normalizedMnemonic,
+    size,
+    category,
+    operands: normalizedOperands,
+    addrMode,
+    flags: { writes, reads },
+    errors: [],
+    prefixes: prefixes.length > 0 ? prefixes : undefined,
+  };
+};
+
+const buildDirectiveLine = (context: ParseContext, mnemonic: string, operands: ParsedOperand[], rawOperands: string[]): ParsedLine => {
+  const addrMode = rawOperands.length > 0 ? rawOperands.join(', ') : 'sin-operandos';
+  return {
+    line: context.line,
+    label: context.label,
+    mnemonic,
+    size: 'inferido',
+    category: 'directive',
+    operands,
+    addrMode,
+    flags: { writes: [], reads: [] },
+    errors: [],
+  };
+};
+
+const buildLabelLine = (context: ParseContext): ParsedLine => ({
+  line: context.line,
+  label: context.label,
+  mnemonic: 'label',
+  size: 'inferido',
+  category: 'label',
+  operands: [],
+  addrMode: 'sin-operandos',
+  flags: { writes: [], reads: [] },
+  errors: [],
+});
+
+const parseDirectiveOperands = (operandsText: string): { operands: ParsedOperand[]; raw: string[]; errors: string[] } => {
+  const errors: string[] = [];
+  if (!operandsText.trim()) {
+    return { operands: [], raw: [], errors };
+  }
+
+  const tokens = splitOperands(operandsText);
+  const operands: ParsedOperand[] = tokens.map((token) => {
+    const trimmed = token.trim();
+    if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+      return createOperand('imm', trimmed, 'inmediato', { string: trimmed.slice(1, -1) });
+    }
+    const number = parseNumber(trimmed);
+    if (number !== null) {
+      return createOperand('imm', trimmed, 'inmediato', { value: number });
+    }
+    if (LABEL_PATTERN.test(trimmed)) {
+      return createOperand('label', trimmed, 'directo', { symbol: trimmed });
+    }
+    errors.push(`Operando de directiva inválido: ${trimmed}`);
+    return createOperand('mem', trimmed, 'desconocido', {});
+  });
+
+  return { operands, raw: tokens, errors };
+};
+
+const parseDirective = (context: ParseContext, directive: string, rest: string): ParsedLine => {
+  const { operands, raw, errors } = parseDirectiveOperands(rest);
+  const line = buildDirectiveLine(context, directive, operands, raw);
+  line.errors.push(...errors);
+  return line;
+};
+
+const parseInstruction = (context: ParseContext, mnemonic: string, rest: string, prefixes: string[] = []): ParsedLine => {
+  const operandResults = parseOperands(rest);
+  const parsedOperands: ParsedOperand[] = [];
+  const errors: string[] = [];
+
+  operandResults.forEach((result) => {
+    if ('error' in result) {
+      errors.push(result.error);
+    } else {
+      parsedOperands.push(result);
+    }
+  });
+
+  const line = buildInstructionLine(context, mnemonic, parsedOperands, prefixes);
+  line.errors.push(...errors);
+  line.errors.push(...validateInstructionOperands(line.mnemonic, line.operands));
+
+  return line;
+};
+
+const parsePrefixedInstruction = (context: ParseContext, prefix: string, remainder: string): ParsedLine => {
+  const trimmed = remainder.trim();
+  if (!trimmed) {
+    const line = buildInstructionLine(context, prefix, [], [prefix]);
+    line.errors.push('Falta la instrucción asociada al prefijo');
+    return line;
+  }
+  const [mnemonic, rest = ''] = trimmed.split(/\s+/, 2);
+  return parseInstruction(context, mnemonic, rest, [prefix]);
+};
+
+const parseLine = (lineText: string, lineNumber: number): ParsedLine[] => {
+  const commentIndex = lineText.indexOf(';');
+  const content = commentIndex >= 0 ? lineText.slice(0, commentIndex) : lineText;
+  const trimmed = content.trim();
+
+  if (!trimmed) {
+    return [];
+  }
+
+  let remaining = trimmed;
+  let label: string | undefined;
+
+  const labelMatch = remaining.match(/^([A-Za-z_][\w]*):/);
+  if (labelMatch) {
+    label = labelMatch[1];
+    remaining = remaining.slice(labelMatch[0].length).trim();
+  }
+
+  const context: ParseContext = { line: lineNumber, label, raw: lineText };
+
+  if (!remaining) {
+    return [buildLabelLine(context)];
+  }
+
+  const [mnemonicRaw, restRaw = ''] = remaining.split(/\s+/, 2);
+  const mnemonic = normalizeMnemonic(mnemonicRaw);
+
+  if (SECTION_DIRECTIVES.has(mnemonic) || DATA_DIRECTIVES.has(mnemonic) || OTHER_DIRECTIVES.has(mnemonic)) {
+    return [parseDirective(context, mnemonic, restRaw)];
+  }
+
+  if (PREFIXES.has(mnemonic)) {
+    return [parsePrefixedInstruction(context, mnemonic, restRaw)];
+  }
+
+  return [parseInstruction(context, mnemonic, restRaw)];
+};
+
+export const analyzeAssembly = (code: string): AssemblyAnalysisResult => {
+  const lines = code.split(/\r?\n/);
+  const parsed: ParsedLine[] = [];
+
+  lines.forEach((line, index) => {
+    const results = parseLine(line, index + 1);
+    parsed.push(...results);
+  });
+
+  return { lines: parsed };
+};
+

--- a/src/features/simulator/asmSimulator.ts
+++ b/src/features/simulator/asmSimulator.ts
@@ -5,8 +5,12 @@ import type {
   SimulationLogEntry,
   SimulationResult,
 } from '../../types';
+import { analyzeAssembly } from './asmParser';
 
 const REGISTER_NAMES: RegisterName[] = ['EAX', 'EBX', 'ECX', 'EDX', 'ESI', 'EDI', 'EBP', 'ESP'];
+
+const stripPrefix = (value: string, prefix: string) =>
+  value.startsWith(prefix) ? value.slice(prefix.length) : value;
 
 const createInitialState = (): CpuState => ({
   registers: REGISTER_NAMES.reduce(
@@ -25,13 +29,14 @@ const createInitialState = (): CpuState => ({
 
 type Operand =
   | { type: 'register'; register: RegisterName }
-  | { type: 'immediate'; value: number };
+  | { type: 'immediate'; value: number }
+  | { type: 'memory'; reference: string };
 
 const isRegister = (value: string): value is RegisterName =>
   REGISTER_NAMES.includes(value.toUpperCase() as RegisterName);
 
 const parseImmediate = (value: string): number | null => {
-  const trimmed = value.trim().toLowerCase();
+  const trimmed = stripPrefix(value.trim(), '$').toLowerCase();
   if (trimmed.startsWith('0x')) {
     const parsed = Number.parseInt(trimmed.slice(2), 16);
     return Number.isNaN(parsed) ? null : parsed;
@@ -48,13 +53,22 @@ const parseImmediate = (value: string): number | null => {
 
 const parseOperand = (rawOperand: string): Operand | null => {
   const cleaned = rawOperand.trim();
-  if (isRegister(cleaned.toUpperCase())) {
-    return { type: 'register', register: cleaned.toUpperCase() as RegisterName };
+  const registerCandidate = stripPrefix(cleaned, '%');
+  if (isRegister(registerCandidate.toUpperCase())) {
+    return { type: 'register', register: registerCandidate.toUpperCase() as RegisterName };
   }
 
   const immediate = parseImmediate(cleaned);
   if (immediate !== null) {
     return { type: 'immediate', value: immediate };
+  }
+
+  if (cleaned.startsWith('(') || cleaned.includes('(') || cleaned.includes(')')) {
+    return { type: 'memory', reference: cleaned };
+  }
+
+  if (/^[A-Za-z_][\w]*(\+|-)?/.test(cleaned)) {
+    return { type: 'memory', reference: cleaned };
   }
 
   return null;
@@ -70,11 +84,14 @@ const setRegister = (state: CpuState, register: RegisterName, value: number) => 
   state.registers[register] = value;
 };
 
-const getOperandValue = (state: CpuState, operand: Operand): number => {
+const getOperandValue = (state: CpuState, operand: Operand): number | null => {
   if (operand.type === 'register') {
     return state.registers[operand.register];
   }
-  return operand.value;
+  if (operand.type === 'immediate') {
+    return operand.value;
+  }
+  return null;
 };
 
 const updateArithmeticFlags = (state: CpuState, result: number) => {
@@ -88,6 +105,18 @@ export const simulateProgram = (code: string): SimulationResult => {
   const state = createInitialState();
   const diagnostics: Diagnostic[] = [];
   const log: SimulationLogEntry[] = [];
+
+  const analysis = analyzeAssembly(code);
+
+  analysis.lines.forEach((line) => {
+    line.errors.forEach((message) => {
+      diagnostics.push({
+        line: line.line,
+        message,
+        severity: 'error',
+      });
+    });
+  });
 
   const lines = code.split(/\r?\n/);
 
@@ -113,7 +142,10 @@ export const simulateProgram = (code: string): SimulationResult => {
 
     const [mnemonicRaw, operandsRaw = ''] = instructionBody.split(/\s+/, 2);
     const mnemonic = mnemonicRaw.toLowerCase();
-    const operands = operandsRaw.split(',').map((operand) => operand.trim()).filter(Boolean);
+    const operands = operandsRaw
+      .split(',')
+      .map((operand) => operand.trim())
+      .filter(Boolean);
 
     const recordError = (message: string) => {
       diagnostics.push({
@@ -138,8 +170,8 @@ export const simulateProgram = (code: string): SimulationResult => {
           return;
         }
 
-        const destination = parseOperand(operands[0]);
-        const source = parseOperand(operands[1]);
+        const source = parseOperand(operands[0]);
+        const destination = parseOperand(operands[1]);
 
         if (!destination || destination.type !== 'register') {
           recordError('El destino de mov debe ser un registro');
@@ -149,8 +181,17 @@ export const simulateProgram = (code: string): SimulationResult => {
           recordError('No se reconoce el operando de origen');
           return;
         }
+        if (source.type === 'memory') {
+          recordError('Operaciones de memoria aún no están soportadas');
+          return;
+        }
 
         const value = getOperandValue(state, source);
+        if (value === null) {
+          recordError('Operando de origen inválido');
+          return;
+        }
+
         setRegister(state, destination.register, value);
         if (destination.register === 'ESP') {
           state.stack = [];
@@ -165,8 +206,8 @@ export const simulateProgram = (code: string): SimulationResult => {
           return;
         }
 
-        const destination = parseOperand(operands[0]);
-        const source = parseOperand(operands[1]);
+        const source = parseOperand(operands[0]);
+        const destination = parseOperand(operands[1]);
 
         if (!destination || destination.type !== 'register') {
           recordError('El destino debe ser un registro');
@@ -176,9 +217,17 @@ export const simulateProgram = (code: string): SimulationResult => {
           recordError('No se reconoce el operando de origen');
           return;
         }
+        if (source.type === 'memory') {
+          recordError('Operaciones de memoria aún no están soportadas');
+          return;
+        }
 
         const currentValue = state.registers[destination.register];
         const operandValue = getOperandValue(state, source);
+        if (operandValue === null) {
+          recordError('Operando de origen inválido');
+          return;
+        }
         const result = mnemonic === 'add' ? currentValue + operandValue : currentValue - operandValue;
         setRegister(state, destination.register, result);
         updateArithmeticFlags(state, result);
@@ -195,7 +244,15 @@ export const simulateProgram = (code: string): SimulationResult => {
           recordError('Operando inválido para push');
           return;
         }
+        if (operand.type === 'memory') {
+          recordError('Operaciones de memoria aún no están soportadas');
+          return;
+        }
         const value = getOperandValue(state, operand);
+        if (value === null) {
+          recordError('Operando inválido para push');
+          return;
+        }
         const newEsp = state.registers.ESP - 4;
         setRegister(state, 'ESP', newEsp);
         state.stack = [value, ...state.stack];
@@ -242,6 +299,7 @@ export const simulateProgram = (code: string): SimulationResult => {
     state: cloneState(state),
     diagnostics,
     log,
+    analysis: analysis.lines,
   };
 };
 

--- a/src/styles/workspace.css
+++ b/src/styles/workspace.css
@@ -29,7 +29,7 @@
 
 .content {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 320px;
+  grid-template-columns: minmax(0, 1fr) 320px 320px;
   grid-template-rows: minmax(320px, auto) minmax(220px, auto);
   gap: 1.5rem;
   padding: 1.5rem;
@@ -78,6 +78,11 @@
   grid-row: 2;
 }
 
+.variablesArea {
+  grid-column: 3;
+  grid-row: 1 / span 2;
+}
+
 .stackList {
   display: flex;
   flex-direction: column;
@@ -87,7 +92,9 @@
   padding-right: 0.5rem;
 }
 
-.stackItem {
+.stackItemButton {
+  width: 100%;
+  text-align: left;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -96,6 +103,14 @@
   background: rgba(30, 41, 59, 0.9);
   border: 1px solid rgba(59, 130, 246, 0.2);
   font-size: 0.9rem;
+  color: inherit;
+  cursor: pointer;
+  transition: transform 0.12s ease, border 0.12s ease;
+}
+
+.stackItemButton:hover {
+  transform: translateY(-2px);
+  border-color: rgba(96, 165, 250, 0.6);
 }
 
 .diagnosticsList {
@@ -277,7 +292,8 @@
   gap: 0.75rem;
 }
 
-.registerCard {
+.registerCardButton {
+  text-align: left;
   background: rgba(30, 41, 59, 0.9);
   border: 1px solid rgba(59, 130, 246, 0.25);
   border-radius: 8px;
@@ -286,6 +302,14 @@
   flex-direction: column;
   gap: 0.25rem;
   font-size: 0.85rem;
+  color: inherit;
+  cursor: pointer;
+  transition: transform 0.12s ease, border 0.12s ease;
+}
+
+.registerCardButton:hover {
+  transform: translateY(-2px);
+  border-color: rgba(147, 197, 253, 0.65);
 }
 
 .registerName {
@@ -300,6 +324,148 @@
   font-size: 0.85rem;
 }
 
+.variablesList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.variableCard {
+  background: rgba(30, 41, 59, 0.9);
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  border-radius: 10px;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.variableHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.variableName {
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.variableDirective {
+  font-size: 0.75rem;
+  color: rgba(125, 211, 252, 0.9);
+}
+
+.variableValues {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.variableValueButton {
+  padding: 0.4rem 0.6rem;
+  border-radius: 6px;
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+  cursor: pointer;
+  transition: transform 0.12s ease, border 0.12s ease;
+  font-size: 0.8rem;
+}
+
+.variableValueButton:hover {
+  transform: translateY(-2px);
+  border-color: rgba(191, 219, 254, 0.8);
+}
+
+.valueInspectorOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1.5rem;
+}
+
+.valueInspectorContent {
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(147, 197, 253, 0.4);
+  border-radius: 16px;
+  max-width: 520px;
+  width: 100%;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 18px 50px rgba(15, 23, 42, 0.5);
+}
+
+.valueInspectorHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.valueInspectorHeader h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.valueInspectorHeader p {
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.valueInspectorClose {
+  border: none;
+  background: rgba(59, 130, 246, 0.9);
+  color: white;
+  border-radius: 6px;
+  padding: 0.4rem 0.75rem;
+  cursor: pointer;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.valueInspectorGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.valueInspectorLabel {
+  display: block;
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.8);
+  margin-bottom: 0.25rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.valueInspectorAscii {
+  letter-spacing: 0.1em;
+}
+
+.valueInspectorBinary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.valueInspectorBinary code {
+  background: rgba(30, 41, 59, 0.9);
+  border-radius: 8px;
+  padding: 0.75rem;
+  white-space: pre-wrap;
+  font-size: 0.85rem;
+  line-height: 1.3;
+}
+
 @media (max-width: 1200px) {
   .workspace {
     grid-template-columns: 100%;
@@ -312,7 +478,7 @@
 
   .content {
     grid-template-columns: 100%;
-    grid-template-rows: repeat(3, auto);
+    grid-template-rows: repeat(4, auto);
   }
 
   .editorArea {
@@ -320,7 +486,24 @@
   }
 
   .stackArea,
-  .registerArea {
+  .registerArea,
+  .variablesArea {
     grid-column: 1;
+  }
+
+  .stackArea {
+    grid-row: 2;
+  }
+
+  .registerArea {
+    grid-row: 3;
+  }
+
+  .variablesArea {
+    grid-row: 4;
+  }
+
+  .valueInspectorContent {
+    max-width: 100%;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,4 +44,61 @@ export interface SimulationResult {
   state: CpuState;
   diagnostics: Diagnostic[];
   log: SimulationLogEntry[];
+  analysis?: ParsedLine[];
+}
+
+export type OperandKind = 'imm' | 'reg' | 'mem' | 'label';
+
+export type OperandAddressMode =
+  | 'inmediato'
+  | 'registro'
+  | 'directo'
+  | 'indirecto'
+  | 'base+desp'
+  | 'base+indice'
+  | 'base+indice+desp'
+  | 'indice-escalado'
+  | 'mixto'
+  | 'relativo'
+  | 'desconocido';
+
+export type InstructionSize = 'b' | 'w' | 'l' | 'inferido';
+
+export type InstructionCategory =
+  | 'data'
+  | 'arith'
+  | 'logic'
+  | 'shift'
+  | 'verify'
+  | 'setcc'
+  | 'branch'
+  | 'cmov'
+  | 'string'
+  | 'stack'
+  | 'misc'
+  | 'directive'
+  | 'label';
+
+export interface ParsedOperand {
+  kind: OperandKind;
+  text: string;
+  addrMode: OperandAddressMode;
+  parsed: Record<string, unknown>;
+}
+
+export interface ParsedLine {
+  line: number;
+  label?: string;
+  mnemonic: string;
+  size: InstructionSize;
+  category: InstructionCategory;
+  operands: ParsedOperand[];
+  addrMode: string;
+  flags: { writes: string[]; reads: string[] };
+  errors: string[];
+  prefixes?: string[];
+}
+
+export interface AssemblyAnalysisResult {
+  lines: ParsedLine[];
 }


### PR DESCRIPTION
## Summary
- document the accepted AT&T syntax and usage examples in `guia.md`
- update the simulator to read `%` registers and `$` immediates while respecting source/destination order
- add an interactive inspector for registers, stack values, and data variables with multi-format displays

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4fd61a1588331a9b9e2279d7d28cf